### PR TITLE
[VIT-112] Remove promoted tab from filter bar

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -26,7 +26,7 @@ class Home extends Component {
 
         this.loadMoreContent = this.loadMoreContent.bind(this);
 
-    } 
+    }
 
     componentDidMount() {
 
@@ -41,7 +41,7 @@ class Home extends Component {
         this.attachScrollListener();
     }
 
-    componentWillReceiveProps(nextProps) {    
+    componentWillReceiveProps(nextProps) {
 
         if( nextProps.match.params.filter !== this.state.filter ) {
             this.setState({
@@ -51,7 +51,7 @@ class Home extends Component {
             () => {
                 this.loadContent(this.state.filter);
             });
-            
+
         }
 
     }
@@ -65,7 +65,7 @@ class Home extends Component {
 
     detachScrollListener() {
         window.document.getElementById('vitContent').removeEventListener('scroll', this.scrollListener)
-    }    
+    }
 
     scrollListener = debounce(() => {
         const el = window.document.getElementById('vitContent');
@@ -102,7 +102,7 @@ class Home extends Component {
 
                 if(err) {
                     console.log("Error:(", err)
-                    
+
                     this.setState({
                         posts: [],
                         no_more_post: true,
@@ -111,7 +111,7 @@ class Home extends Component {
 
                     return;
                 }
-            
+
                 result.splice(0, 1);
                 let all_posts = this.state.posts.concat(result);
 
@@ -126,7 +126,7 @@ class Home extends Component {
         } else if(this.state.filter === 'new') {
 
             steem.api.getDiscussionsByCreated(load_more_query, (err, result) => {
-            
+
                 result.splice(0, 1);
                 let all_posts = this.state.posts.concat(result);
 
@@ -140,22 +140,7 @@ class Home extends Component {
         } else if(this.state.filter === 'hot') {
 
             steem.api.getDiscussionsByHot(load_more_query, (err, result) => {
-            
-                result.splice(0, 1);
-                let all_posts = this.state.posts.concat(result);
 
-                this.setState({
-                    posts: all_posts,
-                    no_more_post: result.length < this.pageSize,
-                    'loading_more': false
-                })
-
-            });
-            
-        } else if(this.state.filter === 'promoted') {
-
-            steem.api.getDiscussionsByPromoted(load_more_query, (err, result) => {
-            
                 result.splice(0, 1);
                 let all_posts = this.state.posts.concat(result);
 
@@ -186,7 +171,7 @@ class Home extends Component {
             steem.api.getDiscussionsByTrending(query, (err, result) => {
 
                 if(err) {
-                    
+
                     this.setState({
                         posts: [],
                         no_more_post: true,
@@ -195,7 +180,7 @@ class Home extends Component {
 
                     return;
                 }
-            
+
                 this.setState({
                     posts: result,
                     no_more_post: result.length < this.pageSize,
@@ -207,9 +192,9 @@ class Home extends Component {
         } else if(filter === 'new') {
 
             steem.api.getDiscussionsByCreated(query, (err, result) => {
-                
+
                 if(err) {
-                    
+
                     this.setState({
                         posts: [],
                         no_more_post: true,
@@ -230,32 +215,9 @@ class Home extends Component {
         } else if(filter === 'hot') {
 
             steem.api.getDiscussionsByHot(query, (err, result) => {
-                
+
                 if(err) {
-                    
-                    this.setState({
-                        posts: [],
-                        no_more_post: true,
-                        loading: false
-                    });
 
-                    return;
-                }
-
-                this.setState({
-                    posts: result,
-                    no_more_post: result.length < this.pageSize,
-                    loading: false
-                });
-
-            });
-            
-        } else if(filter === 'promoted') {
-
-            steem.api.getDiscussionsByPromoted(query, (err, result) => {
-                
-                if(err) {
-                    
                     this.setState({
                         posts: [],
                         no_more_post: true,
@@ -308,18 +270,18 @@ class Home extends Component {
 
                 return (
                     <div className="row">
-                        { 
+                        {
                         this.state.posts.map(
 
                             (Post) =>
                                 <Item key={ Post.id } ref={ Post.id } data={ Post } />
-                            ) 
+                            )
                         }
                     </div>
                 )
             }
 
-            
+
         }
     }
 
@@ -343,17 +305,17 @@ class Home extends Component {
                 }
             </div>
         ]
-        
+
     }
 
 }
 
 function mapStateToProps(state) {
 
-    return { 
+    return {
         search: state.search
     };
-    
+
 }
 
 

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -27,7 +27,7 @@ class Tag extends Component {
 
         this.loadMoreContent = this.loadMoreContent.bind(this);
 
-    } 
+    }
 
     componentDidMount() {
 
@@ -36,7 +36,7 @@ class Tag extends Component {
 
     }
 
-    componentWillReceiveProps(nextProps) {        
+    componentWillReceiveProps(nextProps) {
 
         if( nextProps.match.params.tag !== this.state.tag || nextProps.match.params.filter !== this.state.filter ) {
             this.setState({
@@ -47,7 +47,7 @@ class Tag extends Component {
             () => {
                 this.loadContent(this.state.tag, this.state.filter);
             });
-            
+
         }
 
     }
@@ -61,7 +61,7 @@ class Tag extends Component {
 
     detachScrollListener() {
         window.document.getElementById('vitContent').removeEventListener('scroll', this.scrollListener)
-    }    
+    }
 
     scrollListener = debounce(() => {
         const el = window.document.getElementById('vitContent');
@@ -71,7 +71,7 @@ class Tag extends Component {
         }
     }, 150)
 
-    loadMoreContent () { 
+    loadMoreContent () {
 
         if (this.state.loading_more || this.state.no_more_post) return;
 
@@ -89,7 +89,7 @@ class Tag extends Component {
         if(this.state.filter === 'trending') {
 
             steem.api.getDiscussionsByTrending(load_more_query, (err, result) => {
-            
+
                 result.splice(0, 1);
                 let all_posts = this.state.posts.concat(result);
 
@@ -120,7 +120,7 @@ class Tag extends Component {
         } else if(this.state.filter === 'hot') {
 
             steem.api.getDiscussionsByHot(load_more_query, (err, result) => {
-            
+
                 result.splice(0, 1);
                 let all_posts = this.state.posts.concat(result);
 
@@ -131,24 +131,8 @@ class Tag extends Component {
                 })
 
             });
-            
-        } else if(this.state.filter === 'promoted') {
 
-            steem.api.getDiscussionsByPromoted(load_more_query, (err, result) => {
-            
-                result.splice(0, 1);
-                let all_posts = this.state.posts.concat(result);
-
-                this.setState({
-                    posts: all_posts,
-                    no_more_post: result.length < this.pageSize,
-                    loading_more: false
-                })
-
-            });
-
-        }
-
+        } 
     }
 
     loadContent(tag, filter) {
@@ -161,7 +145,7 @@ class Tag extends Component {
         if(filter === 'trending') {
 
             steem.api.getDiscussionsByTrending(query, (err, result) => {
-            
+
                 this.setState({
                     posts: result,
                     no_more_post: result.length < this.pageSize,
@@ -175,7 +159,7 @@ class Tag extends Component {
             steem.api.getDiscussionsByCreated(query, (err, result) => {
 
                 console.log("err, result", err, result)
-            
+
                 this.setState({
                     posts: result,
                     no_more_post: result.length < this.pageSize,
@@ -187,19 +171,7 @@ class Tag extends Component {
         } else if(filter === 'hot') {
 
             steem.api.getDiscussionsByHot(query, (err, result) => {
-            
-                this.setState({
-                    posts: result,
-                    no_more_post: result.length < this.pageSize,
-                    loading: false
-                });
 
-            });
-            
-        } else if(filter === 'promoted') {
-
-            steem.api.getDiscussionsByPromoted(query, (err, result) => {
-            
                 this.setState({
                     posts: result,
                     no_more_post: result.length < this.pageSize,
@@ -246,12 +218,12 @@ class Tag extends Component {
 
                 return (
                     <div className="row">
-                        { 
+                        {
                         this.state.posts.map(
 
                             (Post) =>
                                 <Item key={ Post.id } ref={ Post.id } data={ Post } />
-                            ) 
+                            )
                         }
                     </div>
                 )
@@ -262,7 +234,7 @@ class Tag extends Component {
     }
 
     render() {
-        
+
         return [
             <FilterBar { ...this.props } key="filter-bar" path={ "/" + this.state.tag + "/" } />,
             <div key="posts">{ this.renderPosts() }</div>,
@@ -281,17 +253,17 @@ class Tag extends Component {
                 }
             </div>
         ]
-        
+
     }
 
 }
 
 function mapStateToProps(state) {
 
-    return { 
+    return {
         search: state.search
     };
-    
+
 }
 
 

--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -10,31 +10,30 @@ class FilterBar extends Component {
 
         this.state = {
 
-        }   
+        }
 
-    } 
+    }
 
     render() {
-        
+
         return [
             <ul className="col filter-bar mb-4" key="filter-bar">
                 <li><NavLink to={ this.props.path + "trending"} className="" activeClassName="active">Trending</NavLink></li>
                 <li><NavLink to={ this.props.path + "new"} className="" activeClassName="active">New</NavLink></li>
                 <li><NavLink to={ this.props.path + "hot"} className="" activeClassName="active">Hot</NavLink></li>
-                <li><NavLink to={ this.props.path + "promoted"} className="" activeClassName="active">Promoted</NavLink></li>
             </ul>
         ]
-        
+
     }
 
 }
 
 function mapStateToProps(state) {
 
-    return { 
+    return {
         search: state.search
     };
-    
+
 }
 
 export default connect(mapStateToProps, {})(FilterBar);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import 'moment-timezone';
 import steem from 'steem';
-import { 
+import {
     API_URL,
     API_ADDRESS_PREFIX,
     API_CHAIN_ID
@@ -63,20 +63,20 @@ ReactDOM.render((
         <Router>
             <Switch>
 
-                <Route exact path="/login/:username?" component={ Login } /> 
-                
+                <Route exact path="/login/:username?" component={ Login } />
+
             	<Bootstrap>
-            
 
-                    <Route 
+
+                    <Route
                         exact
-                        path="/:filter?" 
-                        render={ props => { 
+                        path="/:filter?"
+                        render={ props => {
 
-                            var test_if_home = /trending|new|hot|promoted/.test(props.location.pathname);
+                            var test_if_home = /trending|new|hot/.test(props.location.pathname);
                             var test_if_channel = /@/.test(props.location.pathname);
- 
-                            if(test_if_home) return <Home {...props} /> 
+
+                            if(test_if_home) return <Home {...props} />
                             else if(props.location.pathname === '/upload') return <Upload {...props} />
                             else if(props.location.pathname === '/history') return <History {...props} />
                             else if(props.location.pathname === '/wallet') return <Wallet {...props} />
@@ -86,25 +86,25 @@ ReactDOM.render((
                             else if(test_if_channel) return <Channel {...props} />
                             else return <Redirect to="/new/"/>
 
-                        } } 
+                        } }
                     />
-                    
-                    <Route 
-                        path="/:tag/:filter" 
-                        render={ props => { 
-                            
+
+                    <Route
+                        path="/:tag/:filter"
+                        render={ props => {
+
                             var test_if_post = /@/.test(props.location.pathname);
                             if(!test_if_post) return <Tag {...props} />
                             else return null;
 
                         } }
-                    /> 
-                    <Route path="/@:author/:permalink" component={ Post } /> 
-                	                    
+                    />
+                    <Route path="/@:author/:permalink" component={ Post } />
 
-                </Bootstrap> 
+
+                </Bootstrap>
 
             </Switch>
         </Router>
-    </Provider> 
+    </Provider>
 ), document.getElementById('root'));


### PR DESCRIPTION
Kind of a dirty diff, but this should remove the "Promoted" tab from the filter bar, and remove its handling from the Home and Tag page controllers, as well as the router.

Tested by running it locally and making sure that the Promoted tab doesn't show up for the example categories.

I used Atom to edit this, but I'm not sure why it added quotations around `loading_more` in Tag.js.