### PR TITLE
Display post created time instead of time last modified.

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -53,7 +53,7 @@ class Item extends Component {
                     </div>
                 </div>
                 <div className="meta-info">
-                    <Link to={ "/@" + this.props.data.author }>{ this.props.data.author }</Link> &middot; { moment.utc(this.props.data.active).tz( moment.tz.guess() ).fromNow() }
+                    <Link to={ "/@" + this.props.data.author }>{ this.props.data.author }</Link> &middot; { moment.utc(this.props.data.created).tz( moment.tz.guess() ).fromNow() }
                 </div>
             </div>
         )
@@ -77,7 +77,7 @@ class Item extends Component {
                         </div>
                     </div>
                     <div className="meta-info">
-                        <span>{ this.props.data.category }</span> &middot; { moment.utc(this.props.data.active).tz( moment.tz.guess() ).fromNow() }
+                        <span>{ this.props.data.category }</span> &middot; { moment.utc(this.props.data.created).tz( moment.tz.guess() ).fromNow() }
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Displayed time is deceived on posts as it is using the last modified time. Should use post created time