### PR TITLE
Filter out posts that do not contain an Upload Hash or Playlist on related posts panel

### DIFF
--- a/src/Post.js
+++ b/src/Post.js
@@ -10,6 +10,7 @@ import Item from './components/Item';
 import Avatar from './components/Avatar';
 import Comments from './components/Comments';
 import { VIDEO_THUMBNAIL_URL_PREFIX, LIQUID_TOKEN, AVATAR_UPLOAD_PREFIX, SCREENSHOT_IMAGE } from './config';
+import { shouldDisplayPost } from './utils/Filter'
 
 class Post extends Component {
 
@@ -97,8 +98,6 @@ class Post extends Component {
             return false;
         }
 
-        
-
         this.setState({
             voting: true
         });
@@ -163,9 +162,11 @@ class Post extends Component {
             }
 
             steem.api.getDiscussionsByAuthorBeforeDate(author.replace('@',''), permalink, post.active, 5, (err, result) => {
-                
+
                 result.splice(0, 1);
- 
+
+                result = result.filter((item) => {return shouldDisplayPost(this.state, item)})
+
                 this.setState({
                     loading_related: false,
                     related: result

--- a/src/Post.js
+++ b/src/Post.js
@@ -166,11 +166,16 @@ class Post extends Component {
 
                 result.splice(0, 1);
 
-                result = result.filter((item) => {return shouldDisplayPost(this.state, item)})
+                let related_posts = [];
+
+                result.forEach((item) => {
+                    if(shouldDisplayPost(this.props, item, related_posts))
+                        related_posts.push(item)
+                })
 
                 this.setState({
                     loading_related: false,
-                    related: result
+                    related: related_posts
                 });
 
 

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -75,7 +75,7 @@ class Item extends Component {
                             <Link to={ "/@" + this.props.data.author + "/" + this.props.data.permlink }>{this.truncateTitle(this.props.data.title)}</Link>
                         </h6>
                         <div className="earnings text-right">
-                            ${ this.displayPayoutAmount(this.props.data.pending_payout_value) }
+                            { this.displayPayoutAmount(this.props.data.pending_payout_value) } { LIQUID_TOKEN }
                         </div>
                     </div>
                     <div className="meta-info">


### PR DESCRIPTION
This also changes the $ on the History.js page to LIQUID_TOKEN